### PR TITLE
Prepare kubevirt-apb for v0.3.0

### DIFF
--- a/roles/kubevirt-apb/templates/kubevirt.yaml.j2
+++ b/roles/kubevirt-apb/templates/kubevirt.yaml.j2
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: kubevirt-infra
+  name: kubevirt-controller
   namespace: kube-system
   labels:
     kubevirt.io: ""
@@ -31,8 +31,8 @@ rules:
       - kubevirt.io
     resources:
       - virtualmachines
-      - migrations
       - virtualmachinereplicasets
+      - virtualmachinepresets
     verbs:
       - get
       - list
@@ -45,7 +45,7 @@ rules:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kubevirt-infra
+  name: kubevirt-controller
   namespace: kube-system
   labels:
     kubevirt.io: ""
@@ -53,7 +53,7 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kubevirt-admin
+  name: kubevirt-privileged
   namespace: kube-system
   labels:
     kubevirt.io: ""
@@ -61,23 +61,23 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: kubevirt-infra
+  name: kubevirt-controller
   namespace: kube-system
   labels:
     kubevirt.io: ""
 roleRef:
   kind: ClusterRole
-  name: kubevirt-infra
+  name: kubevirt-controller
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount
-    name: kubevirt-infra
+    name: kubevirt-controller
     namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: kubevirt-infra-cluster-admin
+  name: kubevirt-controller-cluster-admin
   namespace: kube-system
   labels:
     kubevirt.io: ""
@@ -87,7 +87,23 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount
-    name: kubevirt-infra
+    name: kubevirt-controller
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kubevirt-privileged-cluster-admin
+  namespace: kube-system
+  labels:
+    kubevirt.io: ""
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: kubevirt-privileged
     namespace: kube-system
 ---
 # custom resource definitions
@@ -108,21 +124,6 @@ spec:
     shortNames:
       - vm
       - vms
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: migrations.kubevirt.io
-  labels:
-    kubevirt.io: ""
-spec:
-  scope: Namespaced
-  group: kubevirt.io
-  version: v1alpha1
-  names:
-    kind: Migration
-    plural: migrations
-    singular: migration
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -157,7 +158,7 @@ spec:
       labels:
         kubevirt.io: virt-controller
     spec:
-      serviceAccountName: kubevirt-infra
+      serviceAccountName: kubevirt-controller
       containers:
         - name: virt-controller
           image: kubevirt/virt-controller:{{ tag }}
@@ -166,8 +167,6 @@ spec:
               - "/virt-controller"
               - "--launcher-image"
               - "kubevirt/virt-launcher:{{ tag }}"
-              - "--migrator-image"
-              - "kubevirt/virt-migrator:{{ tag }}"
               - "--port"
               - "8182"
           ports:
@@ -205,7 +204,7 @@ spec:
       labels:
         kubevirt.io: virt-handler
     spec:
-      serviceAccountName: kubevirt-infra
+      serviceAccountName: kubevirt-privileged
       hostPID: true
       containers:
         - name: virt-handler
@@ -218,8 +217,6 @@ spec:
             - "/virt-handler"
             - "-v"
             - "3"
-            - "--libvirt-uri"
-            - "qemu:///system"
             - "--hostname-override"
             - "$(NODE_NAME)"
           securityContext:
@@ -247,74 +244,20 @@ spec:
           hostPath:
             path: /var/run/kubevirt-private
 ---
-# libvirt daemon set
-apiVersion: extensions/v1beta1
-kind: DaemonSet
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
 metadata:
-  name: libvirt
-  namespace: kube-system
+  name: virtualmachinepresets.kubevirt.io
   labels:
-    kubevirt.io: "libvirt"
+    kubevirt.io: ""
 spec:
-  template:
-    metadata:
-      name: libvirt
-      labels:
-        kubevirt.io: libvirt
-    spec:
-      serviceAccountName: kubevirt-infra
-      hostNetwork: true
-      hostPID: true
-      hostIPC: true
-      securityContext:
-        runAsUser: 0
-      containers:
-        - name: libvirtd
-          ports:
-            - containerPort: 16509
-              hostPort: 16509
-          image: kubevirt/libvirt-kubevirt:{{ tag }}
-          imagePullPolicy: IfNotPresent
-          securityContext:
-            privileged: true
-            runAsUser: 0
-          volumeMounts:
-            - mountPath: /host-dev
-              name: host-dev
-            - mountPath: /host-sys
-              name: host-sys
-            - name: libvirt-data
-              mountPath: /var/lib/libvirt
-            - name: libvirt-runtime
-              mountPath: /var/run/libvirt
-            - name: virt-share-dir
-              mountPath: /var/run/kubevirt
-            - name: virt-private-dir
-              mountPath: /var/run/kubevirt-private
-          command: ["/libvirtd.sh"]
-        - name: virtlogd
-          image: kubevirt/libvirt-kubevirt:{{ tag }}
-          imagePullPolicy: IfNotPresent
-          volumeMounts:
-            - name: libvirt-runtime
-              mountPath: /var/run/libvirt
-          command: ["/usr/sbin/virtlogd", "-f", "/etc/libvirt/virtlogd.conf"]
-      volumes:
-        - name: libvirt-data
-          hostPath:
-            path: /var/lib/libvirt-container
-        - name: libvirt-runtime
-          hostPath:
-            path: /var/run/libvirt
-        - name: host-dev
-          hostPath:
-            path: /dev
-        - name: host-sys
-          hostPath:
-            path: /sys
-        - name: virt-share-dir
-          hostPath:
-            path: /var/run/kubevirt
-        - name: virt-private-dir
-          hostPath:
-            path: /var/run/kubevirt-private
+  group: kubevirt.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: virtualmachinepresets
+    singular: virtualmachinepreset
+    kind: VirtualMachinePreset
+    shortNames:
+      - vmpreset
+      - vmpresets


### PR DESCRIPTION
Use v0.3.0-alpha-4 as base for the new manifests. They significantly changed since the last update.

Signed-off-by: Roman Mohr <rmohr@redhat.com>