### PR TITLE
Remove kubevirt-infra from adding SCC

### DIFF
--- a/roles/kubevirt-apb/tasks/provision.yml
+++ b/roles/kubevirt-apb/tasks/provision.yml
@@ -9,7 +9,6 @@
   with_items:
     - kubevirt-privileged
     - kubevirt-controller
-    - kubevirt-infra
 
 - name: Download Kubevirt Template
   get_url:


### PR DESCRIPTION
The `kubevirt-infra` service account was removed in kubevirt 0.3