### PR TITLE
Adding CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build_and_push: apb_build docker_push apb_push
 .PHONY: apb_build
 apb_build:
 	docker run --rm --privileged -v $(PWD):/mnt:z -v $(HOME)/.kube:/.kube -v /var/run/docker.sock:/var/run/docker.sock -u $(USER) docker.io/ansibleplaybookbundle/apb-tools:latest prepare
-	docker build -t $(DOCKERHOST)/$(DOCKERORG)/$(IMAGENAME):$(TAG) .
+	docker build -t $(DOCKERHOST)/$(DOCKERORG)/$(IMAGENAME):$(TAG) $(ARGS) .
 
 .PHONY: docker_push
 docker_push:

--- a/automation/check-merged.mounts
+++ b/automation/check-merged.mounts
@@ -1,0 +1,1 @@
+check-patch.mounts

--- a/automation/check-merged.packages
+++ b/automation/check-merged.packages
@@ -1,0 +1,1 @@
+check-patch.packages

--- a/automation/check-merged.sh
+++ b/automation/check-merged.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -xe
+
+source "${0%/*}/common.sh"
+
+main() {
+    common.build_and_tag_apb
+}
+
+[[ "${BASH_SOURCE[0]}" == "$0" ]] && main "$@"

--- a/automation/check-patch.mounts
+++ b/automation/check-patch.mounts
@@ -1,0 +1,1 @@
+/var/run/docker.sock:/var/run/docker.sock

--- a/automation/check-patch.packages
+++ b/automation/check-patch.packages
@@ -1,0 +1,2 @@
+docker
+git

--- a/automation/check-patch.sh
+++ b/automation/check-patch.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -xe
+
+source "${0%/*}/common.sh"
+
+main() {
+    echo "TODO: add tests"
+}
+
+[[ "${BASH_SOURCE[0]}" == "$0" ]] && main "$@"

--- a/automation/common.sh
+++ b/automation/common.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+common.build_and_tag_apb() {
+    # STDCI will publish containers which are tagged with "exported-artifacts"
+    local version && version="$(common.get_version)"
+
+    make \
+        apb_build \
+        TAG=exported-artifacts \
+        ARGS="--label git-sha=$version"
+}
+
+common.get_version() {
+    git describe --tags --match "v*"
+}


### PR DESCRIPTION
- When sending a PR, check patch will be triggered. This script
  should build and test the APB (The test isn't implemented yet).

- When the PR is merged, check-merged will be triggered. This script
  builds and publish the APB at https://hub.docker.com/u/ovirtinfra/

- The APB will have a label called "git-sha", which contains the sha of
  the commit that was used to build the APB.

Signed-off-by: gbenhaim <galbh2@gmail.com>