### PR TITLE
Add version variable to (de)provision playbooks

### DIFF
--- a/playbooks/deprovision.yml
+++ b/playbooks/deprovision.yml
@@ -10,3 +10,4 @@
 - import_playbook: "/etc/ansible/roles/kubevirt-ansible/playbooks/kubevirt.yml"
   vars:
     apb_action: deprovision
+    version: "{{ version }}"

--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -10,3 +10,4 @@
 - import_playbook: "/etc/ansible/roles/kubevirt-ansible/playbooks/kubevirt.yml"
   vars:
     apb_action: provision
+    version: "{{ version }}"


### PR DESCRIPTION
* Make sure `kubevirt-apb` passes version down to `kubevirt-ansible`.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1597270